### PR TITLE
Release 0.1.0/resize layers should be more clear

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -9,6 +9,9 @@ from morph.layers.sparse import sparsify
 from morph._models import EasyMnist
 
 
+def random_dataset():
+    return TensorDataset(torch.randn(2, 28, 28))
+
 def main():
     my_model = EasyMnist()
     # do one pass through the algorithm
@@ -16,7 +19,7 @@ def main():
 
     print(modified) # take a peek at the new layers. You take it from here
 
-    my_dataloader = DataLoader(TensorDataset(torch.randn(2, 28, 28)))
+    my_dataloader = DataLoader(random_dataset)
 
     # get back the class that will do work
     morphed = net.Morph(my_model, epochs=5, dataloader=my_dataloader)

--- a/morph/_error.py
+++ b/morph/_error.py
@@ -1,0 +1,6 @@
+class ValidationError(Exception):
+    """Custom error that represents a validation issue, according to internal
+    system rules
+    """
+    def __init__(self, msg):
+        super(ValidationError, self).__init__(msg)

--- a/morph/_utils.py
+++ b/morph/_utils.py
@@ -1,0 +1,12 @@
+from ._error import ValidationError
+
+
+def check(pred: bool, message='Validation failed'):
+    if not pred: raise ValidationError(message)
+
+
+def round(value: float) -> int:
+    """Rounds a `value` up to the next integer if possible.
+    Performs differently from the standard Python `round`
+    """
+    return int(value + .5)

--- a/morph/nn/shrink.py
+++ b/morph/nn/shrink.py
@@ -1,0 +1,20 @@
+from morph.layers.sparse import percent_waste
+from morph._utils import check, round
+from morph.nn.utils import in_dim, out_dim
+
+import torch.nn as nn
+
+
+def calc_reduced_size(layer: nn.Module) -> (int, int):
+    """Calculates the reduced size of the layer, post training (initial or morphed re-training)
+    so the layers can be resized.
+    """
+    # TODO: remove this guard when properly we protect access to this function
+    check(
+        type(layer) == nn.Conv2d or type(layer) == nn.Linear,
+        'Invalid layer type: ' + type(layer))
+
+    percent_keep = 1 - percent_waste(layer)
+    shrunk_in, shrunk_out = percent_keep * in_dim(layer), percent_keep * out_dim(layer)
+
+    return round(shrunk_in), round(shrunk_out)

--- a/morph/nn/utils.py
+++ b/morph/nn/utils.py
@@ -13,15 +13,14 @@ CL = TypeVar('MODULE_CHILDREN_LIST', ML, List[Tuple[str, nn.Module]])
 def group_layers_by_algo(children_list: CL) -> ML:
     """Group the layers into how they will be acted upon by my implementation of the algorithm:
     1. First child in the list (the "input" layer)
-    2. Slice of all the child, those that are not first nor last
+    2. Slice of all the children, those that are not first nor last
     3. Last child in the list (the "output" layer)
     """
 
     list_len = len(children_list)
 
     # validate input in case I slip up
-    if list_len < 1:
-        raise ValueError('Invalid argument:', children_list)
+    check(list_len > 1, 'Your children_list must be more than a singleton')
 
     if list_len <= 2:
         return children_list  # interface?

--- a/morph/nn/utils.py
+++ b/morph/nn/utils.py
@@ -1,6 +1,7 @@
 import torch.nn as nn
 
 from morph.nn._types import type_name, type_supported
+from morph._utils import check
 
 from typing import List, Tuple, TypeVar
 
@@ -41,6 +42,31 @@ def make_children_list(children_or_named_children):
     Returns: that generator collected as a list
     """
     return [c for c in children_or_named_children]
+
+
+#################### LAYER INSPECTION ####################
+
+
+def in_dim(layer: nn.Module) -> int:
+    check(type_supported(layer))
+
+    if layer_is_linear(layer):
+        return layer.in_features
+    elif layer_is_conv2d(layer):
+        return layer.in_channels
+    else:
+        raise RuntimeError('Inspecting on unsupported layer')
+
+
+def out_dim(layer: nn.Module) -> int:
+    check(type_supported(layer))
+
+    if layer_is_linear(layer):
+        return layer.out_features
+    elif layer_is_conv2d(layer):
+        return layer.out_channels
+    else:
+        raise RuntimeError('Inspecting on unsupported layer')
 
 
 #################### NEW LAYERS ####################

--- a/morph/nn/widen.py
+++ b/morph/nn/widen.py
@@ -1,28 +1,29 @@
 import torch.nn as nn
 
 import logging
-# TODO: nope. This is really long
-from morph.nn.utils import group_layers_by_algo, make_children_list, new_input_layer, new_output_layer, out_dim, redo_layer, type_name, type_supported
+
+from morph.nn.utils import group_layers_by_algo, make_children_list, out_dim, redo_layer
 from morph._utils import round
+from morph.nn._types import type_name, type_supported
 
 
 def resize_layers(net: nn.Module, width_factor: float = 1.4) -> nn.Module:
+    """Perform a uniform layer widening, which increases the output dimension for
+    fully-connected layers and the number of filters for convolutional layers.
+    """
 
     old_layers = make_children_list(net.named_children())
     (first_name, first_layer), middle, last = group_layers_by_algo(old_layers)
 
     first_layer_output_size = first_layer.out_channels  # count of the last layer's out features
 
-    new_out_next_in = int(first_layer_output_size * width_factor)
+    new_out_next_in = round(first_layer_output_size * width_factor)
 
     # NOTE: is there a better way to do this part? Maybe nn.Sequential?
     network = nn.Module()  # new network
 
-    network.add_module(
-        first_name,
-        new_input_layer(first_layer, type_name(first_layer), out_dim=new_out_next_in))
+    network.add_module(first_name, redo_layer(first_layer, new_out=new_out_next_in))
 
-    # TODO: format and utilize the functions in utils for making layers
     for name, child in middle:
         if type_supported(type_name(child)):
 
@@ -32,12 +33,10 @@ def resize_layers(net: nn.Module, width_factor: float = 1.4) -> nn.Module:
             new_out_next_in = new_out
             network.add_module(name, new_layer)
         else:
-            logging.warning(f"Got an incompatible layer: {type(child)}")
-            network.add_module(f'{name}_INCOMPATIBLE', child)
+            logging.warning(f"Encountered a non-resizable layer: {type(child)}")
+            network.add_module(name, child)
 
     last_name, last_layer = last
-    network.add_module(
-        last_name,
-        new_output_layer(last_layer, type_name(last_layer), in_dim=new_out_next_in))
+    network.add_module(last_name, redo_layer(last_layer, new_in=new_out_next_in))
 
     return network

--- a/morph/nn/widen.py
+++ b/morph/nn/widen.py
@@ -1,18 +1,19 @@
 import torch.nn as nn
 
+import logging
 # TODO: nope. This is really long
-from morph.nn.utils import group_layers_by_algo, layer_is_conv2d, make_children_list, new_input_layer, new_output_layer, redo_layer, type_name, type_supported
+from morph.nn.utils import group_layers_by_algo, make_children_list, new_input_layer, new_output_layer, out_dim, redo_layer, type_name, type_supported
+from morph._utils import round
 
 
-# TODO: refactor out width_factor
-def resize_layers(net: nn.Module):
+def resize_layers(net: nn.Module, width_factor: float = 1.4) -> nn.Module:
 
     old_layers = make_children_list(net.named_children())
     (first_name, first_layer), middle, last = group_layers_by_algo(old_layers)
 
     first_layer_output_size = first_layer.out_channels  # count of the last layer's out features
 
-    new_out_next_in = int(first_layer_output_size * 1.4)
+    new_out_next_in = int(first_layer_output_size * width_factor)
 
     # NOTE: is there a better way to do this part? Maybe nn.Sequential?
     network = nn.Module()  # new network
@@ -23,20 +24,16 @@ def resize_layers(net: nn.Module):
 
     # TODO: format and utilize the functions in utils for making layers
     for name, child in middle:
-        # otherwise, we want to
-        _t = type_name(child)
-        if type_supported(_t):
+        if type_supported(type_name(child)):
 
-            new_out = 0
-            # TODO: look up performance on type name access. Maybe this could just be layer_is_conv2d(child)
-            if layer_is_conv2d(_t):
-                new_out = int(child.out_channels * 1.4)
-            else:  # type_name == 'Linear'
-                new_out = int(child.out_features * 1.4)
+            new_out = round(out_dim(child) * width_factor)
 
             new_layer = redo_layer(child, new_in=new_out_next_in, new_out=new_out)
             new_out_next_in = new_out
             network.add_module(name, new_layer)
+        else:
+            logging.warning(f"Got an incompatible layer: {type(child)}")
+            network.add_module(f'{name}_INCOMPATIBLE', child)
 
     last_name, last_layer = last
     network.add_module(


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows the [guidelines](https://chris.beams.io/posts/git-commit/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Completes the working implementation of `resize_layers`, a key step in the "Widen" phase of the MorphNet algorithm.
* Subsequently cuts a lot of the fat from the standing implementation.
* Takes advantage of the utilities that I had set aside for this very purpose.


* **What is the current behavior?** (You can also link to an open issue here)

While the behavior hasn't changed, how those ends are achieved is now different, to resolve #2


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No breaking changes

* **Other information**:
